### PR TITLE
feat(core): 精确处理未识别工作台的两种情况，支持静默通用降级

### DIFF
--- a/Lib/CATAlias.ahk
+++ b/Lib/CATAlias.ahk
@@ -31,7 +31,7 @@ read_user_alias(alias_list_ini_path, section, key) {
         command_id_and_cb_array := process_config(config_str)
     }
     catch as e {
-        if e
+        if e && section != "通用"
         {
             try {
                 AHK_LOGI("调用 通用")
@@ -42,6 +42,10 @@ read_user_alias(alias_list_ini_path, section, key) {
                 k_ToolTip(Format("没有找到与 {1} 对应的命令", key), 1000)
                 return 0
             }
+        }
+        else {
+            k_ToolTip(Format("没有找到与 {1} 对应的命令", key), 1000)
+            return 0
         }
     }
 

--- a/Lib/CAT_Automatic.ahk
+++ b/Lib/CAT_Automatic.ahk
@@ -63,8 +63,8 @@ cat_command_execution(input_string, command_ini, power_input_hwnd) {
     ; 获取当前工作台
     current_workbench := match_current_workbench(AppSettings.workbench_list)
 
-    if !current_workbench {
-        return  ; 如果没有识别到工作台，则终止后续操作
+    if current_workbench == "ERROR_NOT_DOCKED" {
+        return  ; 工具栏未吸附，终止后续操作（已通过 MsgBox 警告）
     }
 
     ; 获取对应的 Command-id 和 回调函数
@@ -238,10 +238,13 @@ match_current_workbench(workbench_map) {
                     return button_name
             }
         }
+        ; WebBrowser 控件存在，但工作台名称未收录在配置中 (情况 2)
+        return "通用"
     }
     catch {
+        ; WebBrowser 控件未找到，工具栏未吸附 (情况 1)
         MsgBox "无法识别当前工作台，请确保【工作台】工具栏是吸附状态"
-        return
+        return "ERROR_NOT_DOCKED"
     }
 }
 


### PR DESCRIPTION
优化未识别工作台下的别名执行逻辑：1. 未吸附工具栏时，弹窗警告并终止；2. 工作台未收录时，静默降级为通用模式。同时避免通用工作台下的冗余回退。